### PR TITLE
Fix: ALFA `killed` when running for too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/*
+.vscode/*
+test/*
+__pycache__

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -203,7 +203,7 @@ class Collector:
 
         print("\n", total_activity_count, "activities saved to:", save_path)
 
-        if return_as_df:
+        if return_as_df and os.path.isfile(f"{save_path}/{logtype[0]}.json"):
             return self.load(f"{save_path}/{logtype[0]}.json")
         return results
 

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -265,7 +265,6 @@ class Collector:
                 for line in f:
                     activities.append(json.loads(line))
                 data = {'activities': activities}
-                print(data)
         if as_activities_df:
             return self.get_activities_df(data)
         return data

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -203,8 +203,8 @@ class Collector:
 
         print("\n", total_activity_count, "activities saved to:", save_path)
 
-        if return_as_df and os.path.isfile(f"{save_path}/{logtype[0]}.json"):
-            return self.load(f"{save_path}/{logtype[0]}.json")
+        if return_as_df:
+            return self.load_all(f"{save_path}")
         return results
 
     def compute_df(self, activities_json: dict) -> pd.DataFrame:
@@ -265,6 +265,7 @@ class Collector:
                 for line in f:
                     activities.append(json.loads(line))
                 data = {'activities': activities}
+                print(data)
         if as_activities_df:
             return self.get_activities_df(data)
         return data

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -204,7 +204,7 @@ class Collector:
         print("\n", total_activity_count, "activities saved to:", save_path)
 
         if return_as_df:
-            return self.load(f"{save_path}/{logtype}.json")
+            return self.load(f"{save_path}/{logtype[0]}.json")
         return results
 
     def compute_df(self, activities_json: dict) -> pd.DataFrame:


### PR DESCRIPTION
Fix an error where large acquisitions fill up the memory of the requesting client, which results in memory being filled up to 25GiB on clients with large amounts of RAM.