### PR TITLE
Fix: upgrade numpy and pyyaml for python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ idna==3.3
 ipython==8.4.0
 jedi==0.18.1
 matplotlib-inline==0.1.3
-numpy==1.22.1
+numpy>=1.26.0,<2.0.0
 oauthlib==3.1.1
 pandas==1.3.5
 parso==0.8.3
@@ -32,7 +32,7 @@ Pygments==2.12.0
 pyparsing==3.0.6
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==6.0
+PyYAML>=6.0.1
 requests==2.27.1
 requests-oauthlib==1.3.0
 rsa==4.8


### PR DESCRIPTION
This PR addresses build failures on Python 3.12 environments caused by outdated dependencies.

### Changes
- Upgraded `numpy` to `>=1.26.0` (required for Python 3.12 wheels/compatibility).
- Upgraded `PyYAML` to `>=6.0.1` (fixes `AttributeError: cython_sources` build error with newer Cython/Setuptools).
- Capped `numpy` at `<2.0.0` to prevent breaking changes from the newest major release.

### Verification
- Tested installation successfully on Python 3.12 (WSL/Ubuntu).
- Confirmed package imports without errors.

Closes #15