### PR TITLE
Bump requirements and add new google log sources

### DIFF
--- a/alfa/config/config.yml
+++ b/alfa/config/config.yml
@@ -28,6 +28,17 @@ logs:
     "vault",
     "gemini_in_workspace_apps",
     "classroom",
+    "meet_hardware",
+    "admin_data_action",
+    "ldap",
+    "profile",
+    "access_evaluation",
+    "assignments",
+    "contacts",
+    "cloud_search",
+    "data_migration",
+    "directory_sync",
+    "tasks"
   ]
 
 activity_defaults:

--- a/alfa/config/config.yml
+++ b/alfa/config/config.yml
@@ -24,6 +24,10 @@ logs:
     "rules",
     "saml",
     "user_accounts",
+    "gmail",
+    "vault",
+    "gemini_in_workspace_apps",
+    "classroom",
   ]
 
 activity_defaults:

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -10,7 +10,7 @@ import json
 from json.decoder import JSONDecodeError
 import os
 import os.path
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 from google.auth.transport.requests import Request
@@ -195,8 +195,16 @@ class Collector:
         if path:
             save_path = path
         for typ in logtype:
+            if typ == "gmail" and not start_time:
+                # gmail log requires start_time to be set to 30 days ago max
+                start = (datetime.now(tz=timezone.utc) - pd.Timedelta(days=30)).isoformat()
+                end = end_time or datetime.now(tz=timezone.utc).isoformat()
+            else:
+                start = start_time
+                end = end_time
+
             res = self.query_one(
-                save_path, save, typ, user, max_results, max_pages, start_time, end_time
+                save_path, save, typ, user, max_results, max_pages, start, end
             )
             total_activity_count += res
             print(f"{typ:>25}:", f"{res:>6}", "activities")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ certifi==2024.7.4
 charset-normalizer==2.0.10
 decorator==5.1.1
 executing==0.8.3
-google-api-core==2.4.0
-google-api-python-client==2.35.0
-google-auth==2.3.3
-google-auth-httplib2==0.1.0
-google-auth-oauthlib==0.4.6
-googleapis-common-protos==1.54.0
+google-api-core==2.29.0
+google-api-python-client==2.188.0
+google-auth==2.47.0
+google-auth-httplib2==0.3.0
+google-auth-oauthlib==1.2.4
+googleapis-common-protos==1.72.0
 httplib2==0.20.2
 idna==3.7
 ipython==8.10.0
@@ -22,7 +22,7 @@ pandas==1.3.5
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
-prompt-toolkit==3.0.29
+prompt-toolkit
 protobuf==4.25.8
 ptyprocess==0.7.0
 pure-eval==0.2.2


### PR DESCRIPTION
This PR adds the `gmail`, `vault`, `gemini_in_workspace_apps` and `classroom` logs as defined on https://developers.google.com/workspace/admin/reports/reference/rest/v1/activities/list#ApplicationName

In order to be able to query these logs the Google SDK requirements needed to be updated