### PR TITLE
upgrade to support Python 3.14 and Pandas 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ALFA
 ## Automated Audit Log Forensic Analysis for Google Workspace
-Copyright (c) 2025 Invictus Incident Response <br>
+Copyright (c) 2026 Invictus Incident Response <br>
 Original authors [Greg Charitonos](https://www.linkedin.com/in/charitonos/) & [BertJanCyber](https://twitter.com/BertJanCyber) maintained by Invictus Incident Response
 
 # Before you start

--- a/alfa/cmdline.py
+++ b/alfa/cmdline.py
@@ -81,7 +81,8 @@ class Parser:
 
     def handle_init(self, args):
         project = Project(args.path)
-        print('now run "alfa analyze"!')
+        print('---')
+        print('Please copy your credentials.json to config/credentials.json and run "alfa acquire"!')
         pass
 
     def handle_load(self, args):

--- a/alfa/config/config.yml
+++ b/alfa/config/config.yml
@@ -24,7 +24,7 @@ logs:
     "rules",
     "saml",
     "user_accounts",
-    "gmail",
+    #"gmail", (this only works if you set the start and endtime and maximum of  30 days)
     "vault",
     "gemini_in_workspace_apps",
     "classroom",

--- a/alfa/config/logo
+++ b/alfa/config/logo
@@ -9,6 +9,6 @@
                                         
 
 Google Workspace Audit Log Forensic Analysis
-Copyright (c) 2025 Invictus Incident Response
+Copyright (c) 2026 Invictus Incident Response
 Original authors (Greg Charitonos & @BertJanCyber) maintained by Invictus Incident Response 
 

--- a/alfa/main/alfa.py
+++ b/alfa/main/alfa.py
@@ -1,12 +1,12 @@
 #!/bin/python3
 import os
+import pandas as pd
 from .analyser import Analyser
 from .activity import Activities, Activity
 from .event import Events
 from pandas.core.series import Series
 from pandas import to_datetime
 from typing import Tuple, Union
-from functools import reduce
 
 from ..config import config
 from .kill_chain import KillChain
@@ -148,7 +148,7 @@ class Alfa:
         if len(activity_slices) == 0: # prevent possible concat on empty list
             return activity_slices
         if concat:
-            res = reduce(lambda a, b: a.append(b), activity_slices)
+            res = pd.concat(activity_slices)
             res = res[~res.index.duplicated()]
             return res
         return activity_slices

--- a/alfa/main/analyser.py
+++ b/alfa/main/analyser.py
@@ -20,18 +20,19 @@ class Analyser:
   
   def analyse_all_files(self, email: list=None,filter=True, subdir=None) -> pd.DataFrame:
     '''Takes all files, analyses and concats into a single DataFrame'''
-    df = pd.DataFrame()
+    dfs = []
     for log in config['logs']:
       log_df = self.analyse_from_file(log,email,filter=filter, subdir=subdir)
-      df = df.append(log_df)
-    return df
+      dfs.append(log_df)
+    return pd.concat(dfs) if dfs else pd.DataFrame()
+
   def analyse_all(self,log_dict,email: list=None,filter=True) -> pd.DataFrame:
     '''takes dict of logs, and analyses and concats them into a single DataFrame'''
-    df = pd.DataFrame()
+    dfs = []
     for log in log_dict:
       log_df = self.analyse(log_dict[log],email,filter=filter)
-      df = df.append(log_df)
-    return df
+      dfs.append(log_df)
+    return pd.concat(dfs) if dfs else pd.DataFrame()
     
   def load_file(self,logtype,subdir=None):
     '''Loads file from data/ directory. If a subdir is given, will load from data/<subdir>'''

--- a/alfa/main/collector.py
+++ b/alfa/main/collector.py
@@ -267,11 +267,16 @@ class Collector:
         with open(json_file) as f:
             try:
                 data = json.load(f)
+                if isinstance(data, dict) and "activities" not in data:
+                    data = {"activities": [data]}
+                elif isinstance(data, list):
+                    data = {"activities": data}
             except JSONDecodeError:
                 f.seek(0)
                 activities = []
                 for line in f:
-                    activities.append(json.loads(line))
+                    if line.strip():
+                        activities.append(json.loads(line))
                 data = {"activities": activities}
         if as_activities_df:
             return self.get_activities_df(data)

--- a/alfa/project_creator/__init__.py
+++ b/alfa/project_creator/__init__.py
@@ -17,8 +17,6 @@ class Project:
     print('initializing project:',abs_path)
     self.__main__()
     print('complete')
-    print('---')
-    print('Please copy your credentials.json to config/credentials.json')
     pass
 
   def __check_can_overwrite(self,path: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.0.10
 decorator==5.1.1
 executing==0.8.3
 google-api-core==2.29.0
-google-api-python-client==2.188.0
+google-api-python-client>=2.150.0
 google-auth==2.47.0
 google-auth-httplib2==0.3.0
 google-auth-oauthlib==1.2.4
@@ -16,9 +16,9 @@ idna==3.7
 ipython==8.10.0
 jedi==0.18.1
 matplotlib-inline==0.1.3
-numpy>=1.26.0,<2.0.0
+numpy>=1.26.0
 oauthlib==3.2.2
-pandas==1.3.5
+pandas>=2.2.0
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5


### PR DESCRIPTION
This PR modernizes the tool to support Python 3.14.

- Dependencies: Unpinned pandas and google-api-python-client in requirements.txt to allow modern versions.
- Refactor: Replaced deprecated df.append() with pd.concat() throughout the codebase (Pandas 2.0+ compliance).
- Fix: Replaced pkg_resources with importlib.metadata to fix build errors on newer Python versions.
- Small textual fixes for copyright banners and help text